### PR TITLE
`@listener` decorator

### DIFF
--- a/tests/fixtures/test_python/test_listener_decorator/conftest.py
+++ b/tests/fixtures/test_python/test_listener_decorator/conftest.py
@@ -1,0 +1,21 @@
+# noqa: INP001
+# init file breaks it
+from robot import model, result
+from robot.api.interfaces import ListenerV3
+from typing_extensions import override
+
+from pytest_robotframework import listener
+
+ran = False
+
+
+@listener
+class Listener(ListenerV3):
+    @override
+    def start_test(
+        self,
+        data: model.TestCase,
+        result: result.TestCase,  # pylint:disable=redefined-outer-name
+    ):
+        global ran
+        ran = True

--- a/tests/fixtures/test_python/test_listener_decorator/test_foo.py
+++ b/tests/fixtures/test_python/test_listener_decorator/test_foo.py
@@ -1,0 +1,13 @@
+# noqa: INP001
+# init file breaks it and i dont care because i hate init files
+from typing import TYPE_CHECKING
+
+# needed because the import needs to be different after the file is moved
+if TYPE_CHECKING:
+    from tests.fixtures.test_python.test_listener_decorator import conftest
+else:
+    import conftest
+
+
+def test_listener():
+    assert conftest.ran

--- a/tests/fixtures/test_python/test_listener_decorator_registered_too_late.py
+++ b/tests/fixtures/test_python/test_listener_decorator_registered_too_late.py
@@ -1,0 +1,12 @@
+from robot.api.interfaces import ListenerV3
+
+from pytest_robotframework import listener
+
+
+@listener
+class Listener(ListenerV3):
+    pass
+
+
+def test_listener():
+    pass

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -319,3 +319,21 @@ def test_xfail_passes_no_reason(pytester_dir: PytesterDir):
         "//kw[contains(@name, ' Run Test') and ./msg[@level='FAIL' and"
         " .='[XPASS(strict)] ']]"
     )
+
+
+def test_listener_decorator(pytester_dir: PytesterDir):
+    run_and_assert_result(pytester_dir, passed=1)
+    assert_log_file_exists(pytester_dir)
+
+
+def test_listener_decorator_registered_too_late(pytester_dir: PytesterDir):
+    result = run_pytest(pytester_dir)
+    result.assert_outcomes(errors=1)
+    # pytest failed before test was collected so nothing in the robot run
+    assert_robot_total_stats(pytester_dir)
+    assert_log_file_exists(pytester_dir)
+    assert (
+        "E   Exception: listener 'Listener' cannot be registered because robot has"
+        " already started running. make sure it's defined in a `conftest.py` file"
+        in result.outlines
+    )


### PR DESCRIPTION
fixes #26 (not really, but i think it's not feasible/necessary to implement robot "libraries" in python tests so i think this is sufficient)