### PR TITLE
fix errors in keywords being raised as `HandlerExecutionFailed` instead of the actual exception which broke `pytest.raises`

### DIFF
--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -29,7 +29,7 @@ from robot.running.statusreporter import StatusReporter
 from robot.utils import getshortdoc
 from typing_extensions import override
 
-from pytest_robotframework._internal.errors import InternalError, UserError
+from pytest_robotframework._internal.errors import UserError
 from pytest_robotframework._internal.robot_utils import execution_context
 from pytest_robotframework._internal.utils import patch_method
 
@@ -147,6 +147,10 @@ class _KeywordDecorator:
                         tags=self.tags,
                     ),
                     context=context,
+                    # we suppress the error in the status reporter because we raise it ourselves
+                    # afterwards, so that context managers like `pytest.raises` can see the actual
+                    # exception instead of `robot.errors.HandlerExecutionFailed`
+                    suppress=True,
                 )
                 if context
                 else nullcontext()
@@ -156,16 +160,10 @@ class _KeywordDecorator:
             status_reporter: AbstractContextManager[None],
             error: BaseException | None = None,
         ):
-            suppress = (
+            if error is None:
                 status_reporter.__exit__(None, None, None)
-                if error is None
-                else status_reporter.__exit__(type(error), error, error.__traceback__)
-            )
-            if suppress:
-                raise InternalError(
-                    "StatusReporter encountered an exception and"
-                    f" `suppress=True`: {error}"
-                ) from error
+            else:
+                status_reporter.__exit__(type(error), error, error.__traceback__)
 
         class WrappedContextManager(AbstractContextManager[T]):
             """defers exiting the status reporter until after the wrapped context

--- a/tests/fixtures/test_python/test_keyword_and_pytest_raises.py
+++ b/tests/fixtures/test_python/test_keyword_and_pytest_raises.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pytest import raises
+
+from pytest_robotframework import keyword
+
+
+class FooError(Exception):
+    pass
+
+
+@keyword
+def bar():
+    raise FooError
+
+
+def test_foo():
+    with raises(FooError):
+        bar()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -524,3 +524,11 @@ def test_pytest_runtest_protocol_hook_multiple_tests(pytester_dir: PytesterDir):
         "//kw[@name='assert' and ./arg['right == left']]/msg[@level='INFO' and"
         " .='1 == 1']"
     )
+
+
+def test_keyword_and_pytest_raises(pytester_dir: PytesterDir):
+    run_and_assert_result(pytester_dir, passed=1)
+    assert_log_file_exists(pytester_dir)
+    assert output_xml(pytester_dir).xpath(
+        "//kw[@name='raises']/kw[@name='bar']/status[@status='FAIL']"
+    )


### PR DESCRIPTION
fixes #74