### PR TITLE
deprecate `continue_on_failure` in favor of `try`/`except` statements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,8 @@
   "robot.codeFormatter": "robotidy",
   "robot.codeLens.interactiveConsole.enable": false,
   "robot.codeLens.enable": false,
-  "explorer.compactFolders": false
+  "explorer.compactFolders": false,
+  "search.exclude": {
+    "pw": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,11 @@
   "git.supportCancellation": true,
   "git.useEditorAsCommitInput": false,
   "diffEditor.ignoreTrimWhitespace": false,
-  "python.linting.mypyArgs": ["--show-column-numbers", "--python-version", "3.8"],
+  "python.linting.mypyArgs": [
+    "--show-column-numbers",
+    "--python-version",
+    "3.8"
+  ],
   "python.linting.mypyEnabled": true,
   "files.autoSave": "onFocusChange",
   "search.useIgnoreFiles": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,17 +36,8 @@
     {
       "label": "basedmypy - all files",
       "type": "shell",
-      "command": "${command:python.interpreterPath} -m mypy -p pytest_robotframework; ${command:python.interpreterPath} -m mypy tests",
-      "presentation": {
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "basedmypy write baseline - all files",
-      "type": "shell",
-      "command": "${command:python.interpreterPath}",
-      "args": ["-m", "mypy", ".", "--write-baseline"],
+      "command": "./pw",
+      "args": ["pdm", "run", "mypy_all"],
       "presentation": {
         "clear": true
       },

--- a/README.md
+++ b/README.md
@@ -269,27 +269,17 @@ keywordify(some_module, "some_function")
 keywordify(some_module.SomeClass, "some_method")
 ```
 
-### `run keyword and continue on failure` doesn't continue after the failure
+### `run_keyword_and_continue_on_failure` doesn't continue after the failure
 
-use the `continue_on_failure` context manager instead
+some robot keywords such as `run_keyword_and_continue_on_failure` don't work properly when called from python code.
 
-```py
-from pytest_robotframework import continue_on_failure
-
-def test_foo():
-    with continue_on_failure():
-        assert 1 == 2  # marks the test as failed but continues the test
-        logger.info("foo")  # doesn't run
-    logger.info("bar")  # does run
-```
-
-you can also check the result like so:
+use a `try`/`except` statement to handle expected failures instead:
 
 ```py
-from pytest_robotframework import continue_on_failure
-
-def test_foo():
-    with continue_on_failure() as result:
-        assert 1 == 2
-    assert result.value == "FAIL"
+try:
+    some_keyword_that_fails()
+except SomeException:
+    ... # ignore the exception, or re-raise it later
 ```
+
+the keyword will still show as failed in the log (as long as it's decorated with `pytest_robotframework.keyword`), but it won't effect the status of the test

--- a/README.md
+++ b/README.md
@@ -282,4 +282,4 @@ except SomeException:
     ... # ignore the exception, or re-raise it later
 ```
 
-the keyword will still show as failed in the log (as long as it's decorated with `pytest_robotframework.keyword`), but it won't effect the status of the test
+the keyword will still show as failed in the log (as long as it's decorated with `pytest_robotframework.keyword`), but it won't effect the status of the test unless the exception is re-raised

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,15 @@ lint = [
 ]
 test = ["lxml>=4.9.3", "lxml-stubs>=0.4.0"]
 
+[tool.pdm.plugins.pytest11]
+robotframework = "pytest_robotframework._internal.plugin"
+
+# maybe these should be pyprojectx scripts instead once https://github.com/pyprojectx/pyprojectx/issues/26 is fixed
+[tool.pdm.scripts]
+_mypy_package = { cmd = "pdm run mypy -p pytest_robotframework" }
+_mypy_tests = { cmd = "pdm run mypy -p tests" }
+mypy_all = { composite = ["_mypy_package", "_mypy_tests"] }
+
 [project.urls]
 repository = "https://github.com/detachhead/pytest-robotframework"
 
@@ -41,12 +50,11 @@ run = "pdm run"
 outdated = "pdm update --outdated"
 test = "pdm run pytest"
 
+
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
 
-[tool.pdm.plugins.pytest11]
-robotframework = "pytest_robotframework._internal.plugin"
 
 [tool.black]
 target-version = ["py38"]

--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -105,7 +105,9 @@ def _runner_for(  # type:ignore[no-any-decorated]
 
 _KeywordResultValue = Union[Literal["PASS"], BaseException, None]
 
-_T_KeywordResult = TypeVar("_T_KeywordResult", bound=_KeywordResultValue)
+_T_KeywordResult = TypeVar(
+    "_T_KeywordResult", covariant=True, bound=_KeywordResultValue
+)
 
 
 @dataclass
@@ -334,9 +336,9 @@ def as_keyword(
     name: str,
     *,
     doc="",
-    tags: tuple[str, ...] | None = None,
-    continue_on_failure: True,  # pylint:disable=redefined-outer-name
-) -> ContextManager[_KeywordResult[_KeywordResultValue]]: ...
+    tags: tuple[str, ...] | None = ...,
+    continue_on_failure: False = ...,  # pylint:disable=redefined-outer-name
+) -> ContextManager[_KeywordResult[Never]]: ...
 
 
 @overload
@@ -344,9 +346,9 @@ def as_keyword(
     name: str,
     *,
     doc="",
-    tags: tuple[str, ...] | None = None,
-    continue_on_failure: False = ...,  # pylint:disable=redefined-outer-name
-) -> ContextManager[_KeywordResult[Never]]: ...
+    tags: tuple[str, ...] | None = ...,
+    continue_on_failure: bool,  # pylint:disable=redefined-outer-name
+) -> ContextManager[_KeywordResult[_KeywordResultValue]]: ...
 
 
 def as_keyword(

--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -335,17 +335,21 @@ def keyword(  # pylint:disable=missing-param-doc
 def as_keyword(
     name: str,
     *,
-    doc="",
+    doc: str = "",
     tags: tuple[str, ...] | None = ...,
-    continue_on_failure: False = ...,  # pylint:disable=redefined-outer-name
+    continue_on_failure: Literal[False] = ...,  # pylint:disable=redefined-outer-name
 ) -> ContextManager[_KeywordResult[Never]]: ...
 
 
 @overload
+@deprecated(
+    "`continue_on_failure` is deprecated. use a `try`/`except` to manually handle the"
+    " failure instead"
+)
 def as_keyword(
     name: str,
     *,
-    doc="",
+    doc: str = "",
     tags: tuple[str, ...] | None = ...,
     continue_on_failure: bool,  # pylint:disable=redefined-outer-name
 ) -> ContextManager[_KeywordResult[_KeywordResultValue]]: ...
@@ -358,14 +362,12 @@ def as_keyword(
     tags: tuple[str, ...] | None = None,
     continue_on_failure=False,  # pylint:disable=redefined-outer-name
 ):
-    """runs the body as a robot keyword. allows you to check whether it passed or failed if
-    `continue_on_failure` is `True`
+    """runs the body as a robot keyword.
 
     example:
     -------
-    >>> with as_keyword("do thing", on_failure="raise later") as result:
+    >>> with as_keyword("do thing"):
     ...     ...
-    ... assert result.value == "PASS" or isinstance(result.value, SomeException)
 
     :param name: the name for the keyword
     :param doc: the documentation to be displayed underneath the keyword in the robot log
@@ -421,6 +423,7 @@ def keywordify(
     )
 
 
+@deprecated("use a `try`/`except` statement to manually handle the exception instead")
 def continue_on_failure() -> ContextManager[_KeywordResult[_KeywordResultValue]]:
     """continues test execution if the body fails, then re-raises the exception at the end of the
     test. equivalent to robot's `run_keyword_and_continue_on_failure` keyword

--- a/tests/fixtures/test_python/test_keyword_decorator_try_except.py
+++ b/tests/fixtures/test_python/test_keyword_decorator_try_except.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from robot.api import logger
+
+from pytest_robotframework import keyword
+
+
+class FooError(Exception):
+    pass
+
+
+@keyword
+def bar():
+    raise FooError
+
+
+def test_foo():
+    try:
+        bar()
+    except FooError:
+        logger.info("hi")  # type:ignore[no-untyped-call]

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -347,6 +347,17 @@ def test_keyword_decorator_context_manager_that_doesnt_suppress(
     assert not xml.xpath("//msg[.='1']")
 
 
+def test_keyword_decorator_try_except(pytester_dir: PytesterDir):
+    run_and_assert_result(pytester_dir, passed=1)
+    assert_log_file_exists(pytester_dir)
+    xml = output_xml(pytester_dir)
+    assert xml.xpath(
+        "//kw[@name='Run Test' and ./status[@status='PASS']]/kw[@name='bar' and"
+        " ./status[@status='FAIL']]/msg[.='FooError']"
+    )
+    assert xml.xpath("//kw[@name='Run Test']/msg[.='hi']")
+
+
 def test_keywordify_keyword_inside_context_manager(pytester_dir: PytesterDir):
     run_and_assert_result(pytester_dir, passed=1)
     assert_log_file_exists(pytester_dir)


### PR DESCRIPTION
all of this is just reinventing the wheel. using `try`/`except` statements instead simplifies things a lot.