### PR TITLE
Pyright

### DIFF
--- a/.github/workflows/check and publish.yaml
+++ b/.github/workflows/check and publish.yaml
@@ -24,6 +24,7 @@ jobs:
       - run: ./pw install
       - run: ./pw run mypy -p pytest_robotframework
       - run: ./pw run mypy tests
+      - run: ./pw run pyright
       - run: ./pw run black --check --diff .
       - run: ./pw run ruff .
       - run: ./pw run pylint pytest_robotframework tests

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -44,6 +44,16 @@
       "problemMatcher": []
     },
     {
+      "label": "pyright - all files",
+      "type": "shell",
+      "command": "./pw",
+      "args": ["run", "pyright"],
+      "presentation": {
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "ruff - all files",
       "type": "shell",
       "command": "${command:python.interpreterPath}",

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "lint", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:eec8da08ed841fd2f8866b695c9abc709498ce097900c8402c7a5dd3ef45ae4a"
+content_hash = "sha256:c85483947f818cdbf0a72d0848ed027404d508086d5122f39c9967c6efab6bda"
 
 [[package]]
 name = "astroid"
@@ -374,6 +374,19 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+summary = "Node.js virtual environment builder"
+dependencies = [
+    "setuptools",
+]
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.2"
 requires_python = ">=3.7"
@@ -444,6 +457,19 @@ dependencies = [
 files = [
     {file = "pylint-3.0.2-py3-none-any.whl", hash = "sha256:60ed5f3a9ff8b61839ff0348b3624ceeb9e6c2a92c514d81c9cc273da3b6bcda"},
     {file = "pylint-3.0.2.tar.gz", hash = "sha256:0d4c286ef6d2f66c8bfb527a7f8a629009e42c99707dec821a03e1b51a4c1496"},
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.334"
+requires_python = ">=3.7"
+summary = "Command line wrapper for pyright"
+dependencies = [
+    "nodeenv>=1.6.0",
+]
+files = [
+    {file = "pyright-1.1.334-py3-none-any.whl", hash = "sha256:dcb13e8358e021189672c4d6ebcad192ab061e4c7225036973ec493183c6da68"},
+    {file = "pyright-1.1.334.tar.gz", hash = "sha256:3adaf10f1f4209575dc022f9c897f7ef024639b7ea5b3cbe49302147e6949cd4"},
 ]
 
 [[package]]
@@ -586,6 +612,16 @@ files = [
     {file = "ruff-0.1.3-py3-none-win_amd64.whl", hash = "sha256:7a18df6638cec4a5bd75350639b2bb2a2366e01222825562c7346674bdceb7ea"},
     {file = "ruff-0.1.3-py3-none-win_arm64.whl", hash = "sha256:12fd53696c83a194a2db7f9a46337ce06445fb9aa7d25ea6f293cf75b21aca9f"},
     {file = "ruff-0.1.3.tar.gz", hash = "sha256:3ba6145369a151401d5db79f0a47d50e470384d0d89d0d6f7fab0b589ad07c34"},
+]
+
+[[package]]
+name = "setuptools"
+version = "68.2.2"
+requires_python = ">=3.8"
+summary = "Easily download, build, install, upgrade, and uninstall Python packages"
+files = [
+    {file = "setuptools-68.2.2-py3-none-any.whl", hash = "sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a"},
+    {file = "setuptools-68.2.2.tar.gz", hash = "sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,23 +15,6 @@ requires-python = ">=3.8,<4.0"
 readme = "README.md"
 license = { text = "MIT" }
 
-[tool.pdm.dev-dependencies]
-lint = [
-    "black>=23",
-    "basedmypy>=2.1",
-    "pylint>=3.0.0a7",
-    "ruff>=0.0.290",
-    "robotframework-robocop>=4.1.0",
-    "robotframework-tidy>=4.5.0",
-]
-test = ["lxml>=4.9.3", "lxml-stubs>=0.4.0"]
-
-# maybe these should be pyprojectx scripts instead once https://github.com/pyprojectx/pyprojectx/issues/26 is fixed
-[tool.pdm.scripts]
-_mypy_package = { cmd = "pdm run mypy -p pytest_robotframework" }
-_mypy_tests = { cmd = "pdm run mypy -p tests" }
-mypy_all = { composite = ["_mypy_package", "_mypy_tests"] }
-
 [project.urls]
 repository = "https://github.com/detachhead/pytest-robotframework"
 
@@ -47,6 +30,23 @@ run = "pdm run"
 outdated = "pdm update --outdated"
 test = "pdm run pytest"
 
+[tool.pdm.dev-dependencies]
+lint = [
+    "black>=23",
+    "basedmypy>=2.1",
+    "pylint>=3.0.0a7",
+    "ruff>=0.0.290",
+    "robotframework-robocop>=4.1.0",
+    "robotframework-tidy>=4.5.0",
+    "pyright>=1.1.334",
+]
+test = ["lxml>=4.9.3", "lxml-stubs>=0.4.0"]
+
+# maybe these should be pyprojectx scripts instead once https://github.com/pyprojectx/pyprojectx/issues/26 is fixed
+[tool.pdm.scripts]
+_mypy_package = { cmd = "pdm run mypy -p pytest_robotframework" }
+_mypy_tests = { cmd = "pdm run mypy -p tests" }
+mypy_all = { composite = ["_mypy_package", "_mypy_tests"] }
 
 [build-system]
 requires = ["pdm-backend"]
@@ -211,7 +211,6 @@ enable = [
     "redundant-u-string-prefix",
     "redundant-unittest-assert",
     "redundant-yields-doc",
-    "reimported",
     "self-cls-assignment",
     "shallow-copy-environ",
     "signature-differs",
@@ -255,7 +254,6 @@ enable = [
     "empty-comment",
     "no-classmethod-decorator",
     "no-staticmethod-decorator",
-    "redefined-variable-type",
     "simplifiable-condition",
     "simplify-boolean-expression",
     "stop-iteration-return",
@@ -296,9 +294,33 @@ ignore_missing_py_typed = true
 module = ['pytest_robotframework.*', 'tests.*']
 default_return = true
 
-# i don't use pyright, this is only to prevent vscode from suggesting imports that won't work in 3.8
 [tool.pyright]
 pythonVersion = "3.8"
+pythonPlatform = "All"
+
+# We don't use pyright for type checking because we use basedmypy:
+reportGeneralTypeIssues = false
+reportInvalidTypeVarUse = false
+reportMissingImports = false
+reportUnboundVariable = false
+reportOptionalOperand = false
+reportOptionalMemberAccess = false
+reportPrivateImportUsage = false
+
+# but some of its lint tier rules are still useful:
+reportUnusedExpression = true
+reportUnusedClass = true
+reportUnusedFunction = true
+reportUnusedVariable = true          # usually covered by ruff https://github.com/astral-sh/ruff/issues/8441
+reportUnusedCoroutine = true
+enableExperimentalFeatures = true
+reportTypeCommentUsage = true
+reportInconsistentConstructor = true
+reportSelfClsParameterName = true
+reportInvalidStubStatement = true
+reportIncompleteStub = true
+reportUnsupportedDunderAll = true
+reportDuplicateImport = true
 
 [tool.ruff]
 unsafe-fixes = true

--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -82,8 +82,10 @@ def import_resource(path: Path | str):
 
 
 # https://github.com/DetachHead/pytest-robotframework/issues/36
-@patch_method(LibraryKeywordRunner)  # type:ignore[arg-type,no-any-decorated,misc]
-def _runner_for(
+@patch_method(  # type:ignore[arg-type,no-any-decorated,misc]
+    LibraryKeywordRunner, "_runner_for"
+)
+def _(
     old_method: Callable[
         [
             LibraryKeywordRunner,
@@ -395,7 +397,7 @@ def keyword(  # pylint:disable=missing-param-doc
 def as_keyword(
     name: str,
     *,
-    doc="",
+    doc: str = "",
     tags: tuple[str, ...] | None = None,
     args: Iterable[str] | None = None,
     kwargs: Mapping[str, str] | None = None,

--- a/pytest_robotframework/_internal/plugin.py
+++ b/pytest_robotframework/_internal/plugin.py
@@ -104,9 +104,10 @@ def _collect_slash_run(session: Session, *, collect_only: bool):
             },
         )
     _registry.too_late = True
-    # needed for log_file listener methods to prevent logger from deactivating after the test is
-    # over
+
     try:
+        # LOGGER is needed for log_file listener methods to prevent logger from deactivating after
+        # the test is over
         with LOGGER:
             robot.main(  # type:ignore[no-untyped-call]
                 [session.path],  # type:ignore[no-any-expr]


### PR DESCRIPTION
pyright is much faster than mypy and seems better at inferring types from modules with incomplete types (like robot) in a lot of cases

TODO: raise these issues on pyright:

- require error code in pyright:ignore
- `reportMissingSuperCall` false positive on `AbstractContextManager._enter__` and `__exit__`
- only check signatures mode (for libraries where you only want to use two type checkers to make sure the public interface works on both, but you only want to use one type checker on your own code)
- ban any expression (the "unknown" rules don't cover all cases)