### PR TITLE
fix crash when xdist is not installed

### DIFF
--- a/pytest_robotframework/_internal/xdist_utils.py
+++ b/pytest_robotframework/_internal/xdist_utils.py
@@ -16,7 +16,7 @@ def get_xdist():
 
 
 def is_xdist_master(session: Session):
-    return session.config.option.numprocesses is not None
+    return get_xdist() is not None and session.config.option.numprocesses is not None
 
 
 def worker_id(session: Session) -> str | None:


### PR DESCRIPTION
https://github.com/DetachHead/pytest-robotframework/issues/172#issuecomment-1929207173