### PR TITLE
Deprecate `@listener` and `@pre_rebot_modifier` decorators and make `RobotOptions` dict fully typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ class Foo(ListenerV3):
 
 def pytest_robot_modify_options(options: RobotOptions, session: Session) -> None:
     if not session.config.option.collectonly:
-        options["listener"].append(Foo())
+        options["loglevel"] = "DEBUG:INFO"
+        options["listener"].append(Foo()) # you can specify instances as listeners, prerebotmodifiers, etc.
 ```
 
 note that not all arguments that the plugin passes to robot will be present in the `args` list. arguments required for the plugin to function (eg. the plugin's listeners and prerunmodifiers) cannot be viewed or modified with this hook

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ since this is a pytest plugin, you should avoid using robot options that have py
 | `robot --exitonfailure`                 | `pytest --maxfail=1`                  |                                                                                                                                                         |
 | `robot --rerunfailed`                   | `pytest --lf`                         |                                                                                                                                                         |
 | `robot --runemptysuite`                 | `pytest --suppress-no-test-exit-code` | requires the [pytest-custom-exit-code](https://pypi.org/project/pytest-custom-exit-code/) plugin                                                        |
-| `robot --exitonerror`                   | `pytest`                              | this is the default behavior. disabling `exitonerror` is not supported as these are often internal robot errors that are dangerous to suppress.         |
 | `robot --help`                          | `pytest --help`                       | all supported robot options will be listed in the `robotframework` section                                                                              |
 
 ## specifying robot options directlty

--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -44,6 +44,7 @@ from typing_extensions import Literal, Never, TypeAlias, deprecated, override
 from pytest_robotframework._internal.cringe_globals import current_item, current_session
 from pytest_robotframework._internal.errors import InternalError, UserError
 from pytest_robotframework._internal.robot_utils import (
+    Listener as _Listener,
     RobotOptions as _RobotOptions,
     add_robot_error,
     escape_robot_str,
@@ -63,23 +64,6 @@ if TYPE_CHECKING:
         _ExecutionContext,  # pyright:ignore[reportPrivateUsage]
     )
 
-
-Listener: TypeAlias = Union[ListenerV2, ListenerV3]
-
-# ideally this would just use an explicit re-export
-# https://github.com/mitmproxy/pdoc/issues/667
-RobotOptions: TypeAlias = _RobotOptions
-"""robot command-line arguments after being parsed by robot into a `dict`.
-
-for example, the following robot options:
-
-```dotenv
-ROBOT_OPTIONS="--listener Foo --listener Bar -d baz"
-```
-
-will be converted to a `dict` like so:
->>> {"listener": ["Foo", "Bar"], "outputdir": "baz"}
-"""
 
 RobotVariables: TypeAlias = Dict[str, object]
 """variable names and values to be set on the suite level. see the `set_variables` function"""
@@ -564,7 +548,7 @@ def keywordify(
 
 
 _T_ListenerOrSuiteVisitor = TypeVar(
-    "_T_ListenerOrSuiteVisitor", bound=Type[Union[Listener, SuiteVisitor]]
+    "_T_ListenerOrSuiteVisitor", bound=Type[Union["Listener", SuiteVisitor]]
 )
 
 
@@ -635,7 +619,7 @@ class _RobotClassRegistry:
             )
 
 
-_T_Listener = TypeVar("_T_Listener", bound=ClassOrInstance[Listener])
+_T_Listener = TypeVar("_T_Listener", bound=ClassOrInstance["Listener"])
 
 
 @deprecated(
@@ -675,3 +659,25 @@ def pre_rebot_modifier(obj: _T_SuiteVisitor) -> _T_SuiteVisitor:
         obj if isinstance(obj, SuiteVisitor) else catch_errors(obj)()
     )
     return obj
+
+
+# ideally these would just use an explicit re-export
+# https://github.com/mitmproxy/pdoc/issues/667
+Listener: TypeAlias = _Listener
+
+RobotOptions: TypeAlias = _RobotOptions
+"""robot command-line arguments after being parsed by robot into a `dict`.
+
+for example, the following robot options:
+
+```dotenv
+ROBOT_OPTIONS="--listener Foo --listener Bar -d baz"
+```
+
+will be converted to a `dict` like so:
+>>> {"listener": ["Foo", "Bar"], "outputdir": "baz"}
+
+any options missing from this `TypedDict` are not allowed to be modified as they interfere with the
+functionality of this plugin. see https://github.com/detachhead/pytest-robotframework#config for
+alternatives
+"""

--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -638,6 +638,10 @@ class _RobotClassRegistry:
 _T_Listener = TypeVar("_T_Listener", bound=ClassOrInstance[Listener])
 
 
+@deprecated(
+    "add listeners using the `pytest_robot_modify_options` hook instead. see"
+    " https://github.com/DetachHead/pytest-robotframework#pytest_robot_modify_options-hook"
+)
 def listener(obj: _T_Listener) -> _T_Listener:
     """registers a class or instance as a global robot listener. listeners using this decorator are
     always enabled and do not need to be registered with the `--listener` robot option.
@@ -655,6 +659,10 @@ def listener(obj: _T_Listener) -> _T_Listener:
 _T_SuiteVisitor = TypeVar("_T_SuiteVisitor", bound=ClassOrInstance[SuiteVisitor])
 
 
+@deprecated(
+    "add pre-rebot modifiers using the `pytest_robot_modify_options` hook instead. see"
+    " https://github.com/DetachHead/pytest-robotframework#pytest_robot_modify_options-hook"
+)
 def pre_rebot_modifier(obj: _T_SuiteVisitor) -> _T_SuiteVisitor:
     """registers a suite visitor as a pre-rebot modifier. classes using this decorator are always
     enabled and do not need to be registered with the `--prerebotmodifier` robot option.

--- a/pytest_robotframework/_internal/robot_utils.py
+++ b/pytest_robotframework/_internal/robot_utils.py
@@ -89,6 +89,7 @@ class RobotOptions(TypedDict):
     parseinclude: list[str]
     stdout: object  # no idea what this is, it's not in the robot docs
     stderr: object  # no idea what this is, it's not in the robot docs
+    exitonerror: bool
 
 
 banned_options = {

--- a/pytest_robotframework/hooks.py
+++ b/pytest_robotframework/hooks.py
@@ -33,4 +33,11 @@ def pytest_robot_modify_options(options: RobotOptions, session: Session):
     `{"listener": ["Foo", "Bar"]}`means `--listener Foo --listener Bar`). you can also specify
     instances of classes to `listener` and `prerebotmodifier`
     :param session: the pytest `Session` object
+
+    example:
+    -------
+    >>> def pytest_robot_modify_options(options: RobotOptions, session: Session) -> None:
+    ... if not session.config.option.collectonly:
+    ...     options["loglevel"] = "DEBUG:INFO"
+    ...     options["listener"].append(Foo())
     """

--- a/pytest_robotframework/hooks.py
+++ b/pytest_robotframework/hooks.py
@@ -30,6 +30,7 @@ def pytest_robot_modify_options(options: RobotOptions, session: Session):
     """modify the arguments passed to robot in-place
 
     :param options: the arguments to be passed to robot in dict format. for example,
-    `{"listener": ["Foo", "Bar"]}`means `--listener Foo --listener Bar`)
+    `{"listener": ["Foo", "Bar"]}`means `--listener Foo --listener Bar`). you can also specify
+    instances of classes to `listener` and `prerebotmodifier`
     :param session: the pytest `Session` object
     """

--- a/tests/fixtures/test_python/test_catch_errors_decorator/conftest.py
+++ b/tests/fixtures/test_python/test_catch_errors_decorator/conftest.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING
 from robot.api.interfaces import ListenerV3
 from typing_extensions import override
 
-from pytest_robotframework import listener
+from pytest_robotframework import listener  # pyright:ignore[reportDeprecated]
 
 if TYPE_CHECKING:
     from robot import result, running
 
 
-@listener
+@listener  # pyright:ignore[reportDeprecated]
 class Listener(ListenerV3):
     @override
     def end_test(self, data: running.TestCase, result: result.TestCase):

--- a/tests/fixtures/test_python/test_catch_errors_decorator_with_non_instance_method/conftest.py
+++ b/tests/fixtures/test_python/test_catch_errors_decorator_with_non_instance_method/conftest.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING
 from robot.api.interfaces import ListenerV3
 from typing_extensions import override
 
-from pytest_robotframework import listener
+from pytest_robotframework import listener  # pyright:ignore[reportDeprecated]
 
 if TYPE_CHECKING:
     from robot import result, running
 
 
-@listener
+@listener  # pyright:ignore[reportDeprecated]
 class Listener(ListenerV3):
     @staticmethod
     def static_method():

--- a/tests/fixtures/test_python/test_listener_decorator/conftest.py
+++ b/tests/fixtures/test_python/test_listener_decorator/conftest.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from robot.api.interfaces import ListenerV3
 from typing_extensions import override
 
-from pytest_robotframework import listener
+from pytest_robotframework import listener  # pyright:ignore[reportDeprecated]
 
 if TYPE_CHECKING:
     from robot import result, running
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 ran = False
 
 
-@listener
+@listener  # pyright:ignore[reportDeprecated]
 class Listener(ListenerV3):
     @override
     def start_test(self, data: running.TestCase, result: result.TestCase):

--- a/tests/fixtures/test_python/test_listener_decorator_registered_too_late.py
+++ b/tests/fixtures/test_python/test_listener_decorator_registered_too_late.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from robot.api.interfaces import ListenerV3
 
-from pytest_robotframework import listener
+from pytest_robotframework import listener  # pyright:ignore[reportDeprecated]
 
 
-@listener
+@listener  # pyright:ignore[reportDeprecated]
 class Listener(ListenerV3):
     pass
 

--- a/tests/fixtures/test_python/test_listener_decorator_stays_active_on_second_test/conftest.py
+++ b/tests/fixtures/test_python/test_listener_decorator_stays_active_on_second_test/conftest.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from robot.api.interfaces import ListenerV3
 from typing_extensions import override
 
-from pytest_robotframework import listener
+from pytest_robotframework import listener  # pyright:ignore[reportDeprecated]
 
 if TYPE_CHECKING:
     from robot import result, running
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 ran = False
 
 
-@listener
+@listener  # pyright:ignore[reportDeprecated]
 class Listener(ListenerV3):
     @override
     def start_test(self, data: running.TestCase, result: result.TestCase):

--- a/tests/fixtures/test_python/test_robot_modify_options_hook_listener_instance/conftest.py
+++ b/tests/fixtures/test_python/test_robot_modify_options_hook_listener_instance/conftest.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robot.api.interfaces import ListenerV3
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from robot import result, running
+
+    from pytest_robotframework import RobotOptions
+
+
+class Foo(ListenerV3):
+    def __init__(self):
+        super().__init__()
+        self.ran = False
+
+    @override
+    def start_test(self, data: running.TestCase, result: result.TestCase):
+        self.ran = True
+
+
+foo = Foo()
+
+
+def pytest_robot_modify_options(options: RobotOptions):
+    options["listener"] = [foo]
+
+
+def pytest_runtest_setup():
+    assert foo.ran

--- a/tests/fixtures/test_python/test_robot_modify_options_hook_listener_instance/test_foo.py
+++ b/tests/fixtures/test_python/test_robot_modify_options_hook_listener_instance/test_foo.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def test_foo():
+    pass

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pytest import ExitCode
+from pytest import ExitCode, mark
 from robot.conf.settings import RobotSettings
 
 from pytest_robotframework import RobotOptions
-from pytest_robotframework._internal.robot_utils import banned_options, cli_defaults
+from pytest_robotframework._internal.robot_utils import (
+    banned_options,
+    cli_defaults,
+    robot_6,
+)
 
 if TYPE_CHECKING:
     from conftest import PytestRobotTester
@@ -17,6 +21,8 @@ def test_no_tests_found_no_files(pr: PytestRobotTester):
     pr.assert_log_file_exists(check_xdist=False)
 
 
+# i don't care to maintain multiple versions of this type so only test against the latest version
+@mark.skipif(robot_6, reason="old robot version")
 def test_robot_options_type_is_up_to_date():
     assert {
         key for key in cli_defaults(RobotSettings) if key not in banned_options

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pytest import ExitCode
+from robot.conf.settings import RobotSettings
+
+from pytest_robotframework import RobotOptions
+from pytest_robotframework._internal.robot_utils import banned_options, cli_defaults
 
 if TYPE_CHECKING:
     from conftest import PytestRobotTester
@@ -11,3 +15,9 @@ if TYPE_CHECKING:
 def test_no_tests_found_no_files(pr: PytestRobotTester):
     pr.run_and_assert_result(exit_code=ExitCode.NO_TESTS_COLLECTED)
     pr.assert_log_file_exists(check_xdist=False)
+
+
+def test_robot_options_type_is_up_to_date():
+    assert {
+        key for key in cli_defaults(RobotSettings) if key not in banned_options
+    } == set(RobotOptions.__annotations__.keys())

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -105,6 +105,11 @@ def test_robot_modify_options_hook(pr: PytestRobotTester):
     pr.assert_log_file_exists()
 
 
+def test_robot_modify_options_hook_listener_instance(pr: PytestRobotTester):
+    pr.run_and_assert_result(passed=1)
+    pr.assert_log_file_exists()
+
+
 def test_listener_calls_log_file(pr: PytestRobotTester):
     result = pr.run_pytest(
         "--robot-listener", str(pr.pytester.path / "Listener.py"), subprocess=True


### PR DESCRIPTION
fixes #184