### PR TITLE
add `AssertOptions` class to allow customizing how assertions are displayed in the robot log

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,33 @@ enable_assertion_pass_hook = true
 
 ![image](https://github.com/DetachHead/pytest-robotframework/assets/57028336/c2525ccf-c1c6-4c06-be79-c36fefd3bed4)
 
+### hiding non-user facing assertions
+
+you may have existing `assert` statements in your codebase that are not intended to be part of your tests (eg. for narrowing types/validating input data) and don't want them to show up in the robot log. there are two ways you can can hide individual `assert` statements from the log:
+
+```py
+from pytest_robotframework import robot_log, hide_asserts_from_robot_log
+
+def test_foo():
+    # hide a single `assert` statement:
+    assert "foo" == "bar", robot_log(False)
+
+    # hide a group of `assert` statements:
+    with hide_asserts_from_robot_log():
+        assert "foo" == "bar"
+        assert "bar" == "baz"
+```
+
+you can also run pytest with the `--no-assertions-in-robot-log` argument to disable `assert` statements in the robot log by default, then use the `robot_log` function to explicitly enable individual `assert` statements:
+
+```py
+from pytest_robotframework import robot_log
+
+def test_foo():
+    assert "foo" == "bar" # hidden from the robot log (when run with --no-assertions-in-robot-log)
+    assert "bar" == "baz", robot_log(True) # not hidden
+```
+
 # limitations with tests written in python
 
 there are some limitations when writing robotframework tests in python. pytest-robotframework includes solutions for these issues.

--- a/README.md
+++ b/README.md
@@ -236,27 +236,57 @@ enable_assertion_pass_hook = true
 you may have existing `assert` statements in your codebase that are not intended to be part of your tests (eg. for narrowing types/validating input data) and don't want them to show up in the robot log. there are two ways you can can hide individual `assert` statements from the log:
 
 ```py
-from pytest_robotframework import robot_log, hide_asserts_from_robot_log
+from pytest_robotframework import AssertOptions, hide_asserts_from_robot_log
 
 def test_foo():
-    # hide a single `assert` statement:
-    assert "foo" == "bar", robot_log(False)
+    # hide a single passing `assert` statement:
+    assert foo == bar, AssertOptions(log_pass=False)
 
-    # hide a group of `assert` statements:
+    # hide a group of passing `assert` statements:
     with hide_asserts_from_robot_log():
-        assert "foo" == "bar"
-        assert "bar" == "baz"
+        assert foo == bar
+        assert bar == baz
 ```
 
-you can also run pytest with the `--no-assertions-in-robot-log` argument to disable `assert` statements in the robot log by default, then use the `robot_log` function to explicitly enable individual `assert` statements:
+note that failing `assert` statements will still show in the log regardless.
+
+you can also run pytest with the `--no-assertions-in-robot-log` argument to disable `assert` statements in the robot log by default, then use `AssertOptions` to explicitly enable individual `assert` statements:
 
 ```py
-from pytest_robotframework import robot_log
+from pytest_robotframework import AssertOptions
 
 def test_foo():
     assert "foo" == "bar" # hidden from the robot log (when run with --no-assertions-in-robot-log)
-    assert "bar" == "baz", robot_log(True) # not hidden
+    assert "bar" == "baz", AssertOptions(log_pass=True) # not hidden
 ```
+
+### customizing assertions
+
+pytest-robotframework allows you to customize the message for the `assert` keyword which appears on both passing and failing assertions:
+
+```py
+assert 1 == 1  # no custom description
+assert 1 == 1, AssertOptions(description="custom description")
+```
+
+![image](https://github.com/DetachHead/pytest-robotframework/assets/57028336/582f3589-0ba2-469d-916d-8945e4feffbb)
+
+you can still pass a custom message to be displayed only when your assertion fails:
+
+```py
+assert 1 == 2, "the values did not match"
+```
+
+however if you want to specify both a custom description and a failure message, you can use the `fail_message` argument:
+
+```py
+assert 1 == 2, "failure message"
+assert 1 == 2, AssertOptions(description="checking values", fail_message="failure message")
+```
+
+![image](https://github.com/DetachHead/pytest-robotframework/assets/57028336/5bae04a0-0545-4df8-9637-59f8f1ef2f04)
+
+note that `enable_assertion_pass_hook` pytest option needs to be enabled for this to work.
 
 # limitations with tests written in python
 

--- a/pytest_robotframework/_internal/plugin.py
+++ b/pytest_robotframework/_internal/plugin.py
@@ -189,7 +189,7 @@ def _collect_or_run(
         },
     )
     # needs to happen before collection cuz that's when the modules being keywordified get imported
-    _keywordify()
+    _keywordify_pytest_functions()
     if collect_only:
         robot_args = {
             **robot_args,
@@ -543,14 +543,17 @@ def pytest_runtest_teardown(item: Item) -> HookWrapperResult:
     save_exception_to_item(item, result)
 
 
-def _keywordify():
+def _keywordify_pytest_functions():
+    # we change the module since these methods get re-exported from pytest but are actually defined
+    # in a gross looking internal `_pytest` module
+    module = "pytest"
     # TODO: should probably keywordify skip as well, but it messes with the handling in
     # robot_library
     # https://github.com/DetachHead/pytest-robotframework/issues/51
     for method in ("fail", "xfail"):
-        keywordify(pytest, method)
+        keywordify(pytest, method, module=module)
     for method in ("deprecated_call", "warns", "raises"):
-        keywordify(pytest, method, wrap_context_manager=True)
+        keywordify(pytest, method, wrap_context_manager=True, module=module)
 
 
 @hookimpl(tryfirst=True)

--- a/pytest_robotframework/_internal/plugin.py
+++ b/pytest_robotframework/_internal/plugin.py
@@ -434,10 +434,12 @@ def visit_Assert(  # noqa: N802
     - https://github.com/pytest-dev/pytest/issues/11984
     - https://github.com/pytest-dev/pytest/issues/11975
     """
+    result = og(self, assert_)
+    if not self.enable_assertion_pass_hook:
+        return result
     assert_msg = assert_.msg or Constant(None)
     if not self.config:
         raise InternalError("failed to rewrite assertion because config was somehow `None`")
-    result = og(self, assert_)
     try:
         main_test = next(statement for statement in result if isinstance(statement, If))
     except StopIteration:

--- a/pytest_robotframework/_internal/plugin.py
+++ b/pytest_robotframework/_internal/plugin.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-from ast import Assert, Call, Constant, Expr, If, Name, copy_location, stmt
+from ast import Assert, Call, Constant, Expr, If, Raise, copy_location, stmt
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Generator, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Callable, Generator, Mapping, cast
 
 import pytest
 from _pytest.assertion import rewrite
-from _pytest.assertion.rewrite import AssertionRewriter, traverse_node, util
+from _pytest.assertion.rewrite import (
+    AssertionRewriter,
+    _get_assertion_exprs,  # pyright:ignore[reportPrivateUsage]
+    traverse_node,
+)
 from _pytest.main import resolve_collection_argument
 from pluggy import Result
 from pytest import Collector, StashKey, TempPathFactory, TestReport, hookimpl
@@ -23,6 +27,7 @@ from robot.rebot import Rebot
 from robot.run import RobotFramework, RobotSettings
 
 from pytest_robotframework import (
+    AssertOptions,
     Listener,
     RobotOptions,
     _hide_asserts_context_manager_key,  # pyright:ignore[reportPrivateUsage]
@@ -35,6 +40,7 @@ from pytest_robotframework import (
     keywordify,
 )
 from pytest_robotframework._internal import cringe_globals
+from pytest_robotframework._internal.cringe_globals import current_item
 from pytest_robotframework._internal.errors import InternalError
 from pytest_robotframework._internal.pytest_exception_getter import save_exception_to_item
 from pytest_robotframework._internal.pytest_robot_items import RobotFile, RobotItem
@@ -261,7 +267,8 @@ def pytest_addoption(parser: Parser):
         action="store_false",
         help="whether to hide passing `assert` statements in the robot log by default. when this is"
         + " disabled, you can make individual `assert` statements show in the log using the"
-        + " `pytest_robotframework.log` function with `show=True`",
+        + " `pytest_robotframework.AssertionOptions` class with `log_pass=True`. see the docs for"
+        + " more information: https://github.com/DetachHead/pytest-robotframework/tree/assertion-ricing#hiding-non-user-facing-assertions",
     )
     for arg_name, default_value in cli_defaults(RobotSettings).items():
         if arg_name in banned_options:
@@ -346,104 +353,132 @@ def pytest_sessionfinish(session: Session) -> HookWrapperResult:
         cringe_globals._current_session = None  # pyright:ignore[reportPrivateUsage]
 
 
-_show_assertions_key = StashKey[Optional[bool]]()
+_explanation_key = StashKey[str]()
 
 
-def _set_show_assertions(show: bool | None = None):  # noqa: FBT001
-    # global state is cringe, but that's how pytest itself does it so whatever
-    config = util._config  # pyright:ignore[reportPrivateUsage]
-    if not config:
-        raise InternalError("config was None")
-    config.stash[_show_assertions_key] = show
+def pytest_assertion_pass(item: Item, expl: str):
+    """getting the explanation from this hook to pass on to the `pytest_robot_assertion` hook"""
+    item.stash[_explanation_key] = expl
 
 
-rewrite._set_show_assertions = _set_show_assertions  # pyright:ignore[reportAttributeAccessIssue]
+def _call_assertion_hook(
+    expression: str,
+    fail_message: object,
+    line_number: int,
+    assertion_error: AssertionError | None,
+    explanation: str | None = None,
+):
+    item = current_item()
+    if not item:
+        raise InternalError("failed to get current item for pytest_robot_assertion hook")
+    if assertion_error and explanation and explanation.startswith("\n"):
+        # pretty gross but we have to remove this trailing \n which means the fail message was None
+        # but the assertion rewriter already wrote the error message thinking it wasn't None because
+        # it was an AssertOptions object
+        explanation = explanation[1:]
+        assertion_error.args = (explanation, *assertion_error.args[1:])
+    item.ihook.pytest_robot_assertion(
+        item=item,
+        expression=expression,
+        fail_message=fail_message,
+        line_number=line_number,
+        assertion_error=assertion_error,
+        explanation=item.stash[_explanation_key] if explanation is None else explanation,
+    )
+
+
+# we aren't patching an existing function here but instead adding a new one to the rewrite module,
+# since the rewritten assert statement needs to call it, and this is the easist way to do that
+rewrite._call_assertion_hook = _call_assertion_hook  # pyright:ignore[reportAttributeAccessIssue]
+
+
+def pytest_robot_assertion(
+    item: Item,
+    expression: str,
+    fail_message: object,
+    explanation: str,
+    assertion_error: AssertionError | None,
+):
+    show_in_log: bool | None = None
+    # we always want to show the assertion if it failed:
+    if assertion_error:
+        show_in_log = True
+    if isinstance(fail_message, AssertOptions):
+        if not assertion_error and fail_message.log_pass is not None:
+            show_in_log = fail_message.log_pass
+        description = fail_message.description
+    else:
+        description = None
+    if show_in_log is None:
+        show_in_log = (
+            item.config.option.assertions_in_robot_log  # pyright:ignore[reportAny]
+            and not item.stash.get(_hide_asserts_context_manager_key, False)
+        )
+    if show_in_log:
+        with as_keyword("assert", args=[expression if description is None else description]):
+            if description is not None:
+                # the original expression was overwritten so we log it here instead
+                logger.info(f"assert {expression}")
+            if assertion_error:
+                raise assertion_error
+            logger.info(explanation)
 
 
 @patch_method(AssertionRewriter)
 def visit_Assert(  # noqa: N802
     og: Callable[[AssertionRewriter, Assert], list[stmt]], self: AssertionRewriter, assert_: Assert
 ) -> list[stmt]:
-    assert_msg = assert_.msg
-    show_assertions: bool | None = None
+    """we patch the assertion rewriter because the hook functions do not give us what we need. see
+    these issues:
+
+    - https://github.com/pytest-dev/pytest/issues/11984
+    - https://github.com/pytest-dev/pytest/issues/11975
+    """
+    assert_msg = assert_.msg or Constant(None)
     if not self.config:
         raise InternalError("failed to rewrite assertion because config was somehow `None`")
-    if (
-        self.enable_assertion_pass_hook
-        and assert_msg
-        and isinstance(assert_msg, Call)
-        and isinstance(assert_msg.func, Name)
-        and assert_msg.func.id == "robot_log"
-    ):
-        args = {keyword.arg: keyword.value for keyword in assert_msg.keywords}
-        if assert_msg.args:
-            # robot_log(False) # noqa: ERA001
-            args["show"] = assert_msg.args[0]
-        if len(assert_msg.args) == 2:
-            args["msg"] = assert_msg.args[1]
-        if "msg" in args:
-            assert_.msg = args["msg"]
-        else:
-            assert_.msg = Constant(value=None)
-        if "show" in args:
-            show = args["show"]
-            if isinstance(show, Constant) and isinstance(show.value, bool):  # pyright:ignore[reportAny]
-                show_assertions = show.value
-            else:
-                raise Exception(
-                    "failed to parse robot_log call in assert statement because `show` argument"
-                    + f"was {show} (expected bool)"
-                )
-        else:
-            # the function was called with invalid arguments, do nothing because it will fail at
-            # runtime anyway
-            pass
-
-        try:
-            # robot_log(False, msg="asdf") # noqa: ERA001
-            # robot_log(show=False, msg="asdf") # noqa: ERA001
-            assert_.msg = next(
-                keyword.value for keyword in assert_msg.keywords if keyword.arg == "msg"
-            )
-        except StopIteration:
-            if len(assert_msg.args) < 2:
-                # robot_log(False) # noqa: ERA001
-                assert_.msg = Constant(value=None)
-            elif len(assert_msg.args) == 2:
-                # robot_log(False, "") # noqa: ERA001
-                assert_.msg = assert_msg.args[1]
-            # if the length is anything else it means the function was called with the wrong
-            # number of arguments. leave it as-is because it will fail at runtime anyway
     result = og(self, assert_)
-    if show_assertions is not None:
-        try:
-            main_test = next(statement for statement in result if isinstance(statement, If))
-        except StopIteration:
-            raise InternalError("failed to find if statement for assertion rewriting") from None
-        main_test.orelse.insert(
-            0, Expr(self.helper("_set_show_assertions", Constant(value=show_assertions)))
+    try:
+        main_test = next(statement for statement in result if isinstance(statement, If))
+    except StopIteration:
+        raise InternalError("failed to find if statement for assertion rewriting") from None
+    expression = _get_assertion_exprs(self.source)[assert_.lineno]
+    # rice the fail statements:
+    raise_statement = cast(Raise, main_test.body.pop())
+    if not raise_statement.exc:
+        raise InternalError("raise statement without exception")
+    main_test.body.append(
+        Expr(
+            self.helper(
+                "_call_assertion_hook",
+                Constant(expression),  # expression
+                assert_msg,  # fail_message
+                Constant(assert_.lineno),  # line_number
+                raise_statement.exc,  # assertion_error
+                cast(Call, raise_statement.exc).args[0],  # explanation
+            )
         )
-        # copied from the end of og, need to rerun this since a new statement was added:
-        for statement in result:
-            for node in traverse_node(statement):
-                _ = copy_location(node, assert_)
+    )
+
+    # rice the pass statements:
+    main_test.orelse.append(
+        Expr(
+            self.helper(
+                "_call_assertion_hook",
+                Constant(expression),  # expression
+                assert_msg,  # fail_message
+                Constant(assert_.lineno),  # line_number
+                Constant(None),  # assertion_error
+                # explanation is handled by the pytest_assertion_pass hook above, since its too
+                # hard to get it from here
+            )
+        )
+    )
+    # copied from the end of og, need to rerun this since a new statement was added:
+    for statement in result:
+        for node in traverse_node(statement):
+            _ = copy_location(node, assert_)
     return result
-
-
-def pytest_assertion_pass(item: Item, orig: str, expl: str):
-    """without this hook, passing assertions won't show up at all in the robot log"""
-    # this matches what's logged if an assertion fails, so we keep it the same here for consistency
-    # (idk why there's no pytest_assertion_fail hook, only reprcompare which is different)
-    show_assertions = item.config.stash.get(_show_assertions_key, None)
-    if show_assertions is None:
-        show_assertions = (
-            item.config.option.assertions_in_robot_log  # pyright:ignore[reportAny]
-            and not item.stash.get(_hide_asserts_context_manager_key, False)
-        )
-    if show_assertions:
-        with as_keyword("assert", args=[orig]):
-            logger.info(expl)
-    item.config.stash[_show_assertions_key] = None
 
 
 def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> TestReport | None:

--- a/pytest_robotframework/_internal/robot_library.py
+++ b/pytest_robotframework/_internal/robot_library.py
@@ -49,6 +49,15 @@ def _call_and_report_robot_edition(
         # make robot show the exception:
         exception = item.stash.get(exception_key, None)
         if exception:
+            status_reporter_exception = getattr(
+                exception, "_pytest_robot_status_reporter_exception", None
+            )
+            if status_reporter_exception:
+                # the exception was already raised and logged inside a keyword, so raise the
+                # ExecutionFailed which will just tell robot that the test failed without logging
+                # the failure again
+                raise status_reporter_exception
+            # tell robot the test failed and also add the failure to the log
             raise exception
         longrepr = report.longrepr
         if isinstance(longrepr, str):

--- a/pytest_robotframework/hooks.py
+++ b/pytest_robotframework/hooks.py
@@ -67,7 +67,9 @@ def pytest_robot_assertion(
     :param line_number:
         the line number containing the `assert` statement
     :param assertion_error:
-        the exception raised if the `assert` statement failed. `None` if the assertion passed
+        the exception raised if the `assert` statement failed. `None` if the assertion passed.
+        you must re-raise the assertion error for the assertion to fail (useful if you want to
+        conditionally ignore an assertion error)
     :param explanation:
         pytest's explanation of the result. the format will be different depending on whether the
         assertion passed or failed
@@ -75,5 +77,5 @@ def pytest_robot_assertion(
     warning:
     -------
     this hook is experimental and relies heavily on patching the internals of pytest. it may break,
-    change or be removed at any time.
+    change or be removed at any time. you should only use this hook if you know what you're doing
     """

--- a/pytest_robotframework/hooks.py
+++ b/pytest_robotframework/hooks.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pytest import hookspec
+from pytest import Item, hookspec
 
 if TYPE_CHECKING:
     from pytest import Session
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 # pyright:reportReturnType=false
 # https://github.com/astral-sh/ruff/issues/7286
 # https://github.com/astral-sh/ruff/issues/9803
-# ruff: noqa: ARG001, FBT001
+# ruff: noqa: ARG001, FBT001, PLR0917
 
 
 @hookspec
@@ -40,4 +40,40 @@ def pytest_robot_modify_options(options: RobotOptions, session: Session):
     ... if not session.config.option.collectonly:
     ...     options["loglevel"] = "DEBUG:INFO"
     ...     options["listener"].append(Foo())
+    """
+
+
+@hookspec
+def pytest_robot_assertion(
+    item: Item,
+    expression: str,
+    fail_message: object,
+    line_number: int,
+    assertion_error: AssertionError | None,
+    explanation: str,
+) -> None:
+    """gets called when an assertion runs. unlike `pytest_assertrepr_compare` and
+    `pytest_assertion_pass`, this hook is executed on both passing and failing assertions, and
+    allows you to see the second argument passed to `assert` statement
+
+    requires the `enable_assertion_pass_hook` pytest option to be enabled
+
+    :param item:
+        the currently running item
+    :param expression:
+        a string containing the the source code of the expression passed to the `assert` statement
+    :param fail_message:
+        the second argument to the `assert` statement, or `None` if there was none provided
+    :param line_number:
+        the line number containing the `assert` statement
+    :param assertion_error:
+        the exception raised if the `assert` statement failed. `None` if the assertion passed
+    :param explanation:
+        pytest's explanation of the result. the format will be different depending on whether the
+        assertion passed or failed
+
+    warning:
+    -------
+    this hook is experimental and relies heavily on patching the internals of pytest. it may break,
+    change or be removed at any time.
     """

--- a/tests/fixtures/test_python/test_assertion_fails_with_assertion_hook.py
+++ b/tests/fixtures/test_python/test_assertion_fails_with_assertion_hook.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def test_foo():
+    left = 1
+    right = 2
+    assert left == right

--- a/tests/fixtures/test_python/test_assertion_fails_with_description.py
+++ b/tests/fixtures/test_python/test_assertion_fails_with_description.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pytest_robotframework import AssertOptions
+
+
+def test_foo():
+    right = 1
+    assert right == "wrong", AssertOptions(log_pass=False, description="asdf")

--- a/tests/fixtures/test_python/test_assertion_fails_with_fail_message_hide_assert.py
+++ b/tests/fixtures/test_python/test_assertion_fails_with_fail_message_hide_assert.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pytest_robotframework import AssertOptions
+
+
+def test_foo():
+    right = 1
+    assert right == "wrong", AssertOptions(log_pass=False, fail_message="asdf")

--- a/tests/fixtures/test_python/test_assertion_fails_with_message_hide_assert.py
+++ b/tests/fixtures/test_python/test_assertion_fails_with_message_hide_assert.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pytest_robotframework import robot_log
+
+
+def test_foo():
+    right = 1
+    assert right == "wrong", robot_log(show=False, msg="asdf")

--- a/tests/fixtures/test_python/test_assertion_fails_with_message_hide_assert.py
+++ b/tests/fixtures/test_python/test_assertion_fails_with_message_hide_assert.py
@@ -1,8 +1,0 @@
-from __future__ import annotations
-
-from pytest_robotframework import robot_log
-
-
-def test_foo():
-    right = 1
-    assert right == "wrong", robot_log(show=False, msg="asdf")

--- a/tests/fixtures/test_python/test_assertion_passes_custom_messages.py
+++ b/tests/fixtures/test_python/test_assertion_passes_custom_messages.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pytest import raises
+
+from pytest_robotframework import AssertOptions
+
+
+def test_foo():
+    left = 1
+    right = 1
+    assert left == right, "doesn't appear"
+    assert right == left, AssertOptions(description="does appear1")
+    with raises(AssertionError):
+        assert right == "wrong", AssertOptions(log_pass=True, fail_message="does appear2")
+    assert right == "wrong", "does appear3"

--- a/tests/fixtures/test_python/test_assertion_passes_hide_assert.py
+++ b/tests/fixtures/test_python/test_assertion_passes_hide_assert.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from pytest_robotframework import robot_log
+from pytest_robotframework import AssertOptions
 
 
 def test_foo():
     left = 1
     right = 1
     assert left == right
-    assert right == left, robot_log(show=False)
+    assert right == left, AssertOptions(log_pass=False)
     assert right == right  # noqa: PLR0124

--- a/tests/fixtures/test_python/test_assertion_passes_hide_assert.py
+++ b/tests/fixtures/test_python/test_assertion_passes_hide_assert.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pytest_robotframework import robot_log
+
+
+def test_foo():
+    left = 1
+    right = 1
+    assert left == right
+    assert right == left, robot_log(show=False)
+    assert right == right  # noqa: PLR0124

--- a/tests/fixtures/test_python/test_assertion_passes_hide_asserts_context_manager.py
+++ b/tests/fixtures/test_python/test_assertion_passes_hide_asserts_context_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pytest_robotframework import hide_asserts_from_robot_log, robot_log
+from pytest_robotframework import AssertOptions, hide_asserts_from_robot_log
 
 
 def test_foo():
@@ -9,6 +9,6 @@ def test_foo():
     assert 1
     with hide_asserts_from_robot_log():
         assert left == right
-        assert right == left, robot_log(show=True)
+        assert right == left, AssertOptions(log_pass=True)
         assert right == right  # noqa: PLR0124
     assert 2

--- a/tests/fixtures/test_python/test_assertion_passes_hide_asserts_context_manager.py
+++ b/tests/fixtures/test_python/test_assertion_passes_hide_asserts_context_manager.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pytest_robotframework import hide_asserts_from_robot_log, robot_log
+
+
+def test_foo():
+    left = 1
+    right = 1
+    assert 1
+    with hide_asserts_from_robot_log():
+        assert left == right
+        assert right == left, robot_log(show=True)
+        assert right == right  # noqa: PLR0124
+    assert 2

--- a/tests/fixtures/test_python/test_assertion_passes_show_assert_when_no_assertions_in_robot_log.py
+++ b/tests/fixtures/test_python/test_assertion_passes_show_assert_when_no_assertions_in_robot_log.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pytest_robotframework import robot_log
+
+
+def test_foo():
+    left = 1
+    right = 1
+    assert left == right, robot_log(show=True)
+    assert right == left
+    assert right == right, robot_log(show=True)  # noqa: PLR0124

--- a/tests/fixtures/test_python/test_assertion_passes_show_assert_when_no_assertions_in_robot_log.py
+++ b/tests/fixtures/test_python/test_assertion_passes_show_assert_when_no_assertions_in_robot_log.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from pytest_robotframework import robot_log
+from pytest_robotframework import AssertOptions
+
+show_in_log = AssertOptions(log_pass=True)
 
 
 def test_foo():
     left = 1
     right = 1
-    assert left == right, robot_log(show=True)
+    assert left == right, show_in_log
     assert right == left
-    assert right == right, robot_log(show=True)  # noqa: PLR0124
+    assert right == right, show_in_log  # noqa: PLR0124

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -570,10 +570,14 @@ def test_assertion_fails_with_assertion_hook(pr: PytestRobotTester):
         pytest_args=["-o", "enable_assertion_pass_hook=true"], subprocess=True, failed=1
     )
     pr.assert_log_file_exists()
-    assert output_xml().xpath(
+    xml = output_xml()
+    assert xml.xpath(
         "//kw[@name='assert' and ./arg[.='left == right'] and ./status[@status='FAIL']]"
         + "/msg[@level='FAIL' and .='assert 1 == 2']"
     )
+    # make sure the error was only logged once , since the exception gets re-raised after the
+    # keyword is over we want to make sure it's not printed multiple times
+    assert len(cast(List[_Element], xml.xpath("///msg[@level='FAIL']"))) == 1
 
 
 def test_assertion_passes_hide_assert(pr: PytestRobotTester):


### PR DESCRIPTION
- fixes #177
- fixes #50