### PR TITLE
fix 0 exit code when a robot import fails while `--exitonerror` is set

### DIFF
--- a/tests/fixtures/test_robot/test_fails_when_import_error_and_exit_on_error.robot
+++ b/tests/fixtures/test_robot/test_fails_when_import_error_and_exit_on_error.robot
@@ -1,0 +1,7 @@
+*** Settings ***
+Library     asdf    # robotcode: ignore
+
+
+*** Test Cases ***
+Foo
+    No Operation

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -287,3 +287,8 @@ def test_nested_keyword_that_fails(pr: PytestRobotTester):
     # make sure the error was only logged once, since the exception gets re-raised after the
     # keyword is over we want to make sure it's not printed multiple times
     assert xpath(xml, "//msg[@level='FAIL']")
+
+
+def test_fails_when_import_error_and_exit_on_error(pr: PytestRobotTester):
+    pr.run_and_assert_assert_pytest_result("--robot-exitonerror", exit_code=ExitCode.INTERNAL_ERROR)
+    assert_robot_total_stats(failed=1)


### PR DESCRIPTION
fixes #259 