### PR TITLE
fix tracebacks in terminal from failures in `.robot` tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,8 @@
     "PATH": "${env:PATH};./.pyprojectx/pdm"
   },
   "python.testing.pytestArgs": ["-n", "auto"],
-  "task.problemMatchers.neverPrompt": true
+  "task.problemMatchers.neverPrompt": true,
+  "python.experiments.optInto": [
+    "pythonTestAdapter"
+  ]
 }

--- a/tests/fixtures/test_robot/test_traceback/test.robot
+++ b/tests/fixtures/test_robot/test_traceback/test.robot
@@ -1,0 +1,7 @@
+*** Settings ***
+Library     util.py
+
+
+*** Test Cases ***
+Foo
+    Thing

--- a/tests/fixtures/test_robot/test_traceback/util.py
+++ b/tests/fixtures/test_robot/test_traceback/util.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def thing():
+    raise Exception("asdf")

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -292,3 +292,12 @@ def test_nested_keyword_that_fails(pr: PytestRobotTester):
 def test_fails_when_import_error_and_exit_on_error(pr: PytestRobotTester):
     pr.run_and_assert_assert_pytest_result("--robot-exitonerror", exit_code=ExitCode.INTERNAL_ERROR)
     assert_robot_total_stats(failed=1)
+
+
+def test_traceback(pr: PytestRobotTester):
+    result = pr.run_pytest("--tb=short")
+    assert """
+util.py:5: in thing
+    raise Exception("asdf")
+E   Exception: asdf
+""" in "\n".join(result.outlines)


### PR DESCRIPTION
fixes #266 