### PR TITLE
fix crash when disabling setups/teardowns by setting them to `None` inside a `.robot` test

### DIFF
--- a/pytest_robotframework/_internal/pytest/robot_file_support.py
+++ b/pytest_robotframework/_internal/pytest/robot_file_support.py
@@ -116,7 +116,7 @@ class RobotItem(Item):
             raise
 
     def _run_keyword(self, keyword: model.Keyword | None):
-        if keyword:
+        if keyword and keyword.name is not None and keyword.name.lower() != "none":
             with self._check_skipped():
                 BuiltIn().run_keyword(  # pyright:ignore[reportUnknownMemberType]
                     keyword.name, *keyword.args

--- a/tests/fixtures/test_robot/test_empty_setup_or_teardown.robot
+++ b/tests/fixtures/test_robot/test_empty_setup_or_teardown.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Test Setup          Log    setup ran
+Test Teardown       Log    teardown ran
+
+
+*** Test Cases ***
+Runs globally defined setup and teardown
+    No Operation
+
+Disable teardown
+    No Operation
+    [Teardown]    None
+
+Disable setup
+    [Setup]    None
+    No Operation

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -306,3 +306,21 @@ util.py:5: in thing
     raise Exception("asdf")
 E   Exception: asdf
 """ in "\n".join(result.outlines)
+
+
+def test_empty_setup_or_teardown(pr: PytestRobotTester):
+    pr.run_and_assert_result(passed=3)
+    pr.assert_log_file_exists()
+    xml = output_xml()
+    assert xpath(
+        xml,
+        "//test[@name='Runs globally defined setup and teardown']/kw[@name='Setup']/kw[@name='Log']"
+        + "/msg[.='setup ran']",
+    )
+    assert xpath(
+        xml,
+        "//test[@name='Runs globally defined setup and teardown']/kw[@name='Teardown']"
+        + "/kw[@name='Log']/msg[.='teardown ran']",
+    )
+    assert not xml.xpath("//test[@name='Disable setup']/kw[@name='Setup']/kw[@name='Log']")
+    assert not xml.xpath("//test[@name='Disable teardown']/kw[@name='Teardown']/kw[@name='Log']")


### PR DESCRIPTION
fixes #276 