### PR TITLE
fix robot logs file paths being outputted to the terminal when running pytest with `--collect-only`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,5 +55,6 @@
   "python.experiments.optInto": [
     "pythonTestAdapter"
   ],
-  "ruff.nativeServer": false // https://github.com/astral-sh/ruff/issues/11751
+  "ruff.nativeServer": false, // https://github.com/astral-sh/ruff/issues/11751
+  "editor.suggest.showWords": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,14 +41,19 @@
   "terminal.integrated.env.windows": {
     "PATH": "${env:PATH};./.pyprojectx/pdm"
   },
-  "terminal.integrated.env.osx": { "PATH": "${env:PATH};./.pyprojectx/pdm" },
+  "terminal.integrated.env.osx": {
+    "PATH": "${env:PATH};./.pyprojectx/pdm"
+  },
   "terminal.integrated.env.linux": {
     "PATH": "${env:PATH};./.pyprojectx/pdm"
   },
-  "python.testing.pytestArgs": ["-n", "auto"],
+  "python.testing.pytestArgs": [
+    "-n",
+    "auto"
+  ],
   "task.problemMatchers.neverPrompt": true,
   "python.experiments.optInto": [
     "pythonTestAdapter"
   ],
-  "ruff.nativeServer": true
+  "ruff.nativeServer": false // https://github.com/astral-sh/ruff/issues/11751
 }

--- a/pytest_robotframework/_internal/pytest/plugin.py
+++ b/pytest_robotframework/_internal/pytest/plugin.py
@@ -652,12 +652,14 @@ def pytest_runtest_protocol(item: Item):
 
 @hookimpl(tryfirst=True)
 def pytest_terminal_summary(terminalreporter: TerminalReporter, config: Config):
+    if config.option.collectonly:  # pyright:ignore[reportAny]
+        return
     args = config.stash.get(_robot_args_key, None)
     if not args or not args["log"]:
         return
     log_file = Path(args["outputdir"], args["log"]).absolute()
     terminalreporter.line("")
-    terminalreporter.line("Robot Framework Output Files:", bold=True)
+    terminalreporter.line("Robot Framework Log File:", bold=True)
     terminalreporter.line(f"Log:     {log_file}")
     terminalreporter.line(f"Log URI: {log_file.as_uri()}")
 

--- a/tests/fixtures/test_python/test_console_summary_collect_only.py
+++ b/tests/fixtures/test_python/test_console_summary_collect_only.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def test_amongus():
+    pass

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -901,7 +901,7 @@ def test_console_summary(pr: PytestRobotTester):
     assert re.search(
         rf"""
 
-Robot Framework Output Files:
+Robot Framework Log File:
 Log:     {re.escape(str(path))}
 Log URI: {re.escape(path.as_uri())}
 """,
@@ -909,6 +909,11 @@ Log URI: {re.escape(path.as_uri())}
     )
     result = pr.run_pytest("--robot-log=", subprocess=True)
     assert "Robot Framework Output Files:" not in result.outlines
+
+
+def test_console_summary_collect_only(pr: PytestRobotTester):
+    result = pr.run_pytest("--robot-outputdir=a", "--robot-log=b", "--collect-only")
+    assert "Robot Framework Log File" not in "\n".join(result.outlines)
 
 
 def test_console_output(pr: PytestRobotTester):


### PR DESCRIPTION
fixes #281 