### PR TITLE
fix `--maxfail` and `--exitfirst` pytest args and show skip reason in the robot log

### DIFF
--- a/pytest_robotframework/_internal/pytest/plugin.py
+++ b/pytest_robotframework/_internal/pytest/plugin.py
@@ -350,7 +350,7 @@ def _robot_run_tests(session: Session, xdist_item: Item | None = None):
             "listener": listeners,
         },
     )
-    # if item_context is not set then it's being run from pytest_runtest_protocol instead of
+    # if xdist_item is not set then it's being run from pytest_runtest_protocol instead of
     # pytest_runtestloop so we don't need to re-implement pytest_runtest_protocol
     if xdist_item:
         robot_options = merge_robot_options(

--- a/pytest_robotframework/_internal/robot/library.py
+++ b/pytest_robotframework/_internal/robot/library.py
@@ -40,13 +40,11 @@ def _call_and_report_robot_edition(
     if report.skipped:
         # empty string means xfail with no reason, None means it was not an xfail
         xfail_reason = report.wasxfail if hasattr(report, "wasxfail") else None
-        BuiltIn().skip(
-            # TODO: is there a reliable way to get the reason when skipped by a skip/skipif marker?
-            # https://github.com/DetachHead/pytest-robotframework/issues/51
-            ""
-            if xfail_reason is None
-            else ("xfail" + (f": {xfail_reason}" if xfail_reason else ""))
-        )
+        if xfail_reason is None:
+            skip_reason = report.longrepr[2] if isinstance(report.longrepr, tuple) else ""
+        else:
+            skip_reason = "xfail" + (f": {xfail_reason}" if xfail_reason else "")
+        BuiltIn().skip(skip_reason)
     elif report.failed:
         # make robot show the exception:
         exception = item.stash.get(exception_key, None)

--- a/tests/fixtures/test_python/test_exitfirst.py
+++ b/tests/fixtures/test_python/test_exitfirst.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def test_foo():
+    raise Exception
+
+
+def test_bar(): ...

--- a/tests/fixtures/test_python/test_maxfail.py
+++ b/tests/fixtures/test_python/test_maxfail.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def test_foo():
+    raise Exception
+
+
+def test_bar():
+    raise Exception
+
+
+def test_baz(): ...

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -7,7 +7,7 @@ from re import search
 from typing import TYPE_CHECKING, List, cast
 
 from _pytest.assertion.util import running_on_ci
-from pytest import ExitCode, MonkeyPatch
+from pytest import ExitCode, MonkeyPatch, skip
 
 from pytest_robotframework._internal.robot.utils import robot_6
 from tests.conftest import (
@@ -943,3 +943,19 @@ def test_console_output(pr: PytestRobotTester):
             assert f"Output:  {pr.pytester.path / 'output.xml'}" in result.outlines
         else:
             assert "Output:  output.xml" in result.outlines
+
+
+def test_exitfirst(pr: PytestRobotTester):
+    if pr.xdist:
+        skip(
+            "--exitfirst doesn't work with xdist. https://github.com/pytest-dev/pytest-xdist/issues/420"
+        )
+    pr.run_and_assert_result("-x", failed=1, skipped=1)
+
+
+def test_maxfail(pr: PytestRobotTester):
+    if pr.xdist:
+        skip(
+            "--maxfail doesn't work with xdist. https://github.com/pytest-dev/pytest-xdist/issues/868"
+        )
+    pr.run_and_assert_result("--maxfail=2", failed=2, skipped=1)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -36,7 +36,8 @@ def test_one_test_skipped(pr: PytestRobotTester):
     pr.run_and_assert_result(skipped=1)
     pr.assert_log_file_exists()
     assert output_xml().xpath(
-        "./suite//test[@name='test_one_test_skipped']/kw[@type='SETUP']/msg[@level='SKIP']"
+        "./suite//test[@name='test_one_test_skipped']/kw[@type='SETUP']/msg[@level='SKIP' and "
+        + ".='Skipped: foo']"
     )
 
 


### PR DESCRIPTION
- fixes #288 
- fixes #51