### PR TITLE
Truncate arguments to keywords in the robot log if the values are too long

### DIFF
--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -248,11 +248,20 @@ class _KeywordDecorator:
 
         @wraps(fn)
         def inner(*args: P.args, **kwargs: P.kwargs) -> T:
+            def truncate(arg: object) -> str:
+                """robotframework usually just uses the argument as it was written in the source
+                code, but since we can't easily access that in python, we use the actual value
+                instead, but that can sometimes be huge so we truncate it. you can see the full
+                value when running with the DEBUG loglevel anyway"""
+                max_length = 20
+                value = str(arg)
+                return value[:max_length] + "..." if len(value) > max_length else value
+
             if self._module is None:
                 self._module = fn.__module__
             log_args = (
-                *(str(arg) for arg in args),
-                *(f"{key}={value!s}" for key, value in kwargs.items()),
+                *(truncate(arg) for arg in args),
+                *(f"{key}={truncate(value)}" for key, value in kwargs.items()),
             )
             context = execution_context()
             data = running.Keyword(name=keyword_name, args=log_args)

--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -264,10 +264,9 @@ class _KeywordDecorator:
             context_manager: SuppressableContextManager[
                 object
                 # nullcontext is typed as returning None which pyright incorrectly marks as
-                # unreachable. see ContextManager documentation
+                # unreachable. see SuppressableContextManager documentation
             ] = (  # pyright:ignore[reportAssignmentType]
                 (
-                    # needed to work around pyright bug, see ContextManager documentation
                     _FullStackStatusReporter(
                         data=data,
                         result=(

--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -253,7 +253,7 @@ class _KeywordDecorator:
                 code, but since we can't easily access that in python, we use the actual value
                 instead, but that can sometimes be huge so we truncate it. you can see the full
                 value when running with the DEBUG loglevel anyway"""
-                max_length = 20
+                max_length = 50
                 value = str(arg)
                 return value[:max_length] + "..." if len(value) > max_length else value
 

--- a/tests/fixtures/test_python/test_keyword_decorator_args.py
+++ b/tests/fixtures/test_python/test_keyword_decorator_args.py
@@ -8,5 +8,9 @@ def foo(*args: object, **kwargs: object):  # noqa: ARG001
     ...
 
 
-def test_keyword_decorator_with_args():
+def test_no_truncation():
     foo(1, bar=True)
+
+
+def test_truncation():
+    foo("a" * 21, bar="b" * 21)

--- a/tests/fixtures/test_python/test_keyword_decorator_args.py
+++ b/tests/fixtures/test_python/test_keyword_decorator_args.py
@@ -13,4 +13,4 @@ def test_no_truncation():
 
 
 def test_truncation():
-    foo("a" * 21, bar="b" * 21)
+    foo("a" * 51, bar="b" * 51)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -326,7 +326,7 @@ def test_keyword_decorator_args(pr: PytestRobotTester):
     )
     assert xml.xpath(
         ".//test[@name='test_truncation']//kw[@name='Run Test']/kw[@name='Foo' and"
-        + " ./arg[.='aaaaaaaaaaaaaaaaaaaa...'] and ./arg[.='bar=bbbbbbbbbbbbbbbbbbbb...']]"
+        + f" ./arg[.='{'a' * 50}...'] and ./arg[.='bar={'b' * 50}...']]"
     )
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -317,10 +317,16 @@ def test_keyword_decorator_docstring_on_next_line(pr: PytestRobotTester):
 
 
 def test_keyword_decorator_args(pr: PytestRobotTester):
-    pr.run_and_assert_result(passed=1)
+    pr.run_and_assert_result(passed=2)
     pr.assert_log_file_exists()
-    assert output_xml().xpath(
-        ".//kw[@name='Run Test']/kw[@name='Foo' and ./arg[.='1'] and ./arg[.='bar=True']]"
+    xml = output_xml()
+    assert xml.xpath(
+        ".//test[@name='test_no_truncation']//kw[@name='Run Test']/kw[@name='Foo' and ./arg[.='1']"
+        + " and ./arg[.='bar=True']]"
+    )
+    assert xml.xpath(
+        ".//test[@name='test_truncation']//kw[@name='Run Test']/kw[@name='Foo' and"
+        + " ./arg[.='aaaaaaaaaaaaaaaaaaaa...'] and ./arg[.='bar=bbbbbbbbbbbbbbbbbbbb...']]"
     )
 
 


### PR DESCRIPTION
fixes #299