### PR TITLE
fix robot `pass execution` and `pass execution if` incorrectly causing the test to fail

### DIFF
--- a/tests/fixtures/test_robot/test_pass_execution.robot
+++ b/tests/fixtures/test_robot/test_pass_execution.robot
@@ -1,0 +1,3 @@
+*** Test Cases ***
+Asdf
+    Pass Execution    hi

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -335,3 +335,8 @@ def test_keyword_decorator_class_library(pr: PytestRobotTester):
         output_xml(),
         f"//kw[@name='Foo' and @{'library' if robot_6 else 'owner'}='ClassLibrary']/msg[.='hi']",
     )
+
+
+def test_pass_execution(pr: PytestRobotTester):
+    pr.run_and_assert_result(passed=1)
+    pr.assert_log_file_exists()


### PR DESCRIPTION
fixes #333