### PR TITLE
keywordify the new `RaisesGroup` context manager that was introduced in pytest 8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev-dependencies = [
   "robotcode[analyze]>=0.97.0",
   "dprint-py>=0.49.1.2",
   "ty>=0.0.0a8",
+  "exceptiongroup>=1.3.0",
 ]
 
 [tool.uv.build-backend]

--- a/pytest_robotframework/_internal/pytest/plugin.py
+++ b/pytest_robotframework/_internal/pytest/plugin.py
@@ -635,7 +635,11 @@ def _keywordify_pytest_functions():
     # https://github.com/DetachHead/pytest-robotframework/issues/51
     for method in ("fail", "xfail"):
         keywordify(pytest, method, module=module)
-    for method in ("deprecated_call", "warns", "raises"):
+    methods_to_wrap = {"deprecated_call", "warns", "raises"}
+    if pytest_version >= (8, 4):
+        # RaisesGroup was only introduced in pytest 8.4
+        methods_to_wrap.add("RaisesGroup")
+    for method in methods_to_wrap:
         keywordify(pytest, method, wrap_context_manager=True, module=module)
 
 

--- a/tests/fixtures/test_python/test_keywordify_class_context_manager.py
+++ b/tests/fixtures/test_python/test_keywordify_class_context_manager.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from exceptiongroup import ExceptionGroup
+from pytest import RaisesGroup
+
+
+def test_foo():
+    # keywordified in plugin.py
+    exceptions = (ZeroDivisionError, TypeError)
+    # https://github.com/astral-sh/ty/issues/247 and/or https://github.com/astral-sh/ty/issues/493
+    with RaisesGroup(*exceptions):  # ty:ignore[no-matching-overload]
+        raise ExceptionGroup("asdf", [cls() for cls in exceptions])

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -7,7 +7,7 @@ from re import search
 from typing import TYPE_CHECKING, cast
 
 from _pytest.assertion.util import running_on_ci
-from pytest import ExitCode, MonkeyPatch, skip
+from pytest import ExitCode, MonkeyPatch, mark, skip, version_tuple as pytest_version
 
 from pytest_robotframework._internal.robot.utils import robot_6
 from tests.conftest import (
@@ -416,6 +416,16 @@ def test_keywordify_context_manager(pr: PytestRobotTester):
     assert output_xml().xpath(
         "//kw[@name='Raises' and ./arg[.=\"<class 'ZeroDivisionError'>\"] and"
         " ./status[@status='PASS']]"
+    )
+
+
+@mark.skipif(pytest_version < (8, 4), reason="RaisesGroup was introduced in pytest 8.4")
+def test_keywordify_class_context_manager(pr: PytestRobotTester):
+    pr.run_and_assert_result(passed=1)
+    pr.assert_log_file_exists()
+    assert output_xml().xpath(
+        "//kw[@name='Raises Group' and ./arg[.=\"<class 'ZeroDivisionError'>\"] and"
+        " ./arg[.=\"<class 'TypeError'>\"] and ./status[@status='PASS']]"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -507,6 +507,7 @@ dependencies = [
 dev = [
     { name = "basedpyright" },
     { name = "dprint-py" },
+    { name = "exceptiongroup" },
     { name = "lxml" },
     { name = "lxml-stubs" },
     { name = "pdoc" },
@@ -531,6 +532,7 @@ requires-dist = [
 dev = [
     { name = "basedpyright", specifier = ">=1.10.1" },
     { name = "dprint-py", specifier = ">=0.49.1.2" },
+    { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "lxml", specifier = ">=4.9.3" },
     { name = "lxml-stubs", specifier = ">=0.4.0" },
     { name = "pdoc", specifier = ">=14.1.0" },


### PR DESCRIPTION
fixes #349