### PR TITLE
add `max_argument_length_in_log` argument to `keyword` decorator

### DIFF
--- a/pytest_robotframework/_internal/pytest/plugin.py
+++ b/pytest_robotframework/_internal/pytest/plugin.py
@@ -383,7 +383,7 @@ def pytest_addoption(parser: Parser):
     group = parser.getgroup(
         "robot",
         "robotframework (if an option is missing, it means there's a pytest equivalent you should"
-        "use instead. see https://github.com/DetachHead/pytest-robotframework#config)",
+        "use instead. see https://detachhead.github.io/pytest-robotframework/pytest_robotframework.html#config)",
     )
     group.addoption(
         "--no-assertions-in-robot-log",
@@ -393,7 +393,7 @@ def pytest_addoption(parser: Parser):
         help="whether to hide passing `assert` statements in the robot log by default. when this is"
         " disabled, you can make individual `assert` statements show in the log using the"
         " `pytest_robotframework.AssertionOptions` class with `log_pass=True`. see the docs for"
-        " more information: https://github.com/DetachHead/pytest-robotframework/tree/assertion-ricing#hiding-non-user-facing-assertions",
+        " more information: https://detachhead.github.io/pytest-robotframework/pytest_robotframework.html#enabling-pytest-assertions-in-the-robot-log",
     )
     for arg_name, default_value in cli_defaults(RobotSettings).items():
         if arg_name in banned_options:

--- a/tests/fixtures/test_python/test_keyword_decorator_args.py
+++ b/tests/fixtures/test_python/test_keyword_decorator_args.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pytest_robotframework import keyword
 
 
-@keyword
+@keyword(max_argument_length_in_log=60)
 def foo(*args: object, **kwargs: object):  # pyright:ignore[reportUnusedParameter]
     ...
 
@@ -13,4 +13,4 @@ def test_no_truncation():
 
 
 def test_truncation():
-    foo("a" * 51, bar="b" * 51)
+    foo("a" * 61, bar="b" * 61)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -332,7 +332,7 @@ def test_keyword_decorator_args(pr: PytestRobotTester):
     )
     assert xml.xpath(
         ".//test[@name='test_truncation']//kw[@name='Run Test']/kw[@name='Foo' and"
-        f" ./arg[.='{'a' * 50}...'] and ./arg[.='bar={'b' * 50}...']]"
+        f" ./arg[.='{'a' * 60}...'] and ./arg[.='bar={'b' * 60}...']]"
     )
 
 


### PR DESCRIPTION
fixes #343