### PR TITLE
don't include marker args when displaying markers as tags in the robot log as they are often too noisy

### DIFF
--- a/pytest_robotframework/_internal/robot/listeners_and_suite_visitors.py
+++ b/pytest_robotframework/_internal/robot/listeners_and_suite_visitors.py
@@ -163,13 +163,7 @@ class PythonParser(Parser):
                     test_case = running.TestCase(
                         name=child.name,
                         doc=documentation,
-                        tags=[
-                            ":".join([
-                                marker.name,
-                                *(str(arg) for arg in cast(tuple[object, ...], marker.args)),
-                            ])
-                            for marker in child.iter_markers()
-                        ],
+                        tags=[marker.name for marker in child.iter_markers()],
                         parent=parent_suite,
                     )
                     child.stash[running_test_case_key] = test_case

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -440,7 +440,7 @@ def test_parameterized_tags(pr: PytestRobotTester):
     pr.run_and_assert_result(passed=1)
     pr.assert_log_file_exists()
     xml = output_xml()
-    assert xml.xpath(".//test[@name='test_tags']/tag[.='foo:bar']")
+    assert xml.xpath(".//test[@name='test_tags']/tag[.='foo']")
 
 
 def test_keyword_names(pr: PytestRobotTester):


### PR DESCRIPTION
fixes #358