### PR TITLE
fix crash that causes corrupted robot xml when a context manager decorated with `@keyword(wrap_context_manager=True)` raises an exception in its `__enter__` method

### DIFF
--- a/pytest_robotframework/__init__.py
+++ b/pytest_robotframework/__init__.py
@@ -378,7 +378,11 @@ class _WrappedContextManagerKeywordDecorator(_KeywordDecorator):
             # https://github.com/DetachHead/basedpyright/issues/294
             def __enter__(self) -> object:  # pyright:ignore[reportMissingSuperCall]
                 _ = self.status_reporter.__enter__()
-                return self.wrapped.__enter__()
+                try:
+                    return self.wrapped.__enter__()
+                except BaseException as e:
+                    _ = self.status_reporter.__exit__(type(e), e, e.__traceback__)
+                    raise
 
             @override
             def __exit__(

--- a/tests/fixtures/test_python/test_keyword_decorator_context_manager_that_raises_in_enter.py
+++ b/tests/fixtures/test_python/test_keyword_decorator_context_manager_that_raises_in_enter.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from robot.api import logger
+
+from pytest_robotframework import keyword
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@keyword(wrap_context_manager=True)
+@contextmanager
+def asdf() -> Iterator[None]:
+    raise Exception("asdf")
+    # even though this is unreachable, the yield statement is still needed to make the function a
+    # generator for the `contextmanager` decorator to work correctly
+    yield  # pyright: ignore[reportUnreachable]
+
+
+def test_foo():
+    with asdf():
+        logger.info("0")
+    logger.info("1")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -318,7 +318,7 @@ def test_keyword_decorator_docstring(pr: PytestRobotTester):
     assert output_xml().xpath(".//kw[@name='Run Test']/kw[@name='Foo']/doc[.='hie']")
 
 
-def test_keyword_decorator_docstring_on_next_line(pr: PytestRobotTester):
+def test_keyword_decorator_docstring_on_next_line(pr: PytestRobotTester) -> None:
     pr.run_and_assert_result(passed=1)
     pr.assert_log_file_exists()
     assert output_xml().xpath(".//kw[@name='Run Test']/kw[@name='Foo']/doc[.='hie']")
@@ -354,6 +354,15 @@ def test_keyword_decorator_context_manager_that_doesnt_suppress(pr: PytestRobotT
     assert xml.xpath("//kw[@name='Asdf']/msg[@level='INFO' and .='0']")
     assert xml.xpath("//kw[@name='Asdf']/msg[@level='INFO' and .='end']")
     assert xml.xpath("//kw[@name='Asdf' and ./status[@status='FAIL'] and ./msg[.='Exception']]")
+    assert not xml.xpath("//msg[.='1']")
+
+
+def test_keyword_decorator_context_manager_that_raises_in_enter(pr: PytestRobotTester):
+    pr.run_and_assert_result(failed=1)
+    pr.assert_log_file_exists()
+    xml = output_xml()
+    assert xml.xpath("//kw[@name='Asdf']/msg[@level='FAIL' and .='asdf']")
+    assert not xml.xpath("//kw[@name='Asdf']/msg[@level='INFO' and .='0']")
     assert not xml.xpath("//msg[.='1']")
 
 


### PR DESCRIPTION
fixes #372 