### PR TITLE
fix keywords that get called from a `.py` file in a `.robot` test only appearing in the robot log on the first call

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,8 +34,6 @@ jobs:
           fetch-depth: 0 # fetch all commits/branches
       - uses: actions/setup-python@v5
         id: install_python
-        with:
-          python-version: 3.12
       - name: Configure Git user
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,9 @@
   "[toml][json][jsonc][yaml][markdown][github-actions-workflow]": {
     "editor.defaultFormatter": "dprint.dprint"
   },
+  "[robotframework]": {
+    "editor.defaultFormatter": "d-biehl.robotcode"
+  },
   "robotcode.testExplorer.enabled": false,
   "explorer.compactFolders": false,
   "search.exclude": {

--- a/dprint.json
+++ b/dprint.json
@@ -8,8 +8,8 @@
     ".basedpyright/baseline.json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/json-0.20.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.19.0.wasm",
+    "https://plugins.dprint.dev/json-0.21.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.20.0.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
   ]

--- a/tests/fixtures/test_robot/test_keyword_called_twice_in_robot_test/a.robot
+++ b/tests/fixtures/test_robot/test_keyword_called_twice_in_robot_test/a.robot
@@ -1,0 +1,7 @@
+*** Settings ***
+Library     ./foo.py
+
+
+*** Test Cases ***
+Asdfasdf
+    Bar

--- a/tests/fixtures/test_robot/test_keyword_called_twice_in_robot_test/foo.py
+++ b/tests/fixtures/test_robot/test_keyword_called_twice_in_robot_test/foo.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pytest_robotframework import keyword
+
+
+@keyword
+def foo(): ...
+
+
+@keyword
+def bar():
+    foo()
+    foo()

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -342,3 +342,11 @@ def test_keyword_decorator_class_library(pr: PytestRobotTester):
 def test_pass_execution(pr: PytestRobotTester):
     pr.run_and_assert_result(passed=1)
     pr.assert_log_file_exists()
+
+
+def test_keyword_called_twice_in_robot_test(pr: PytestRobotTester):
+    pr.run_and_assert_result(passed=1)
+    pr.assert_log_file_exists()
+    results = output_xml().xpath("//kw[@name='Run Test']/kw[@name='Bar']/kw[@name='Foo']")
+    assert isinstance(results, list)
+    assert len(results) == 2


### PR DESCRIPTION
fixes #377